### PR TITLE
Opam file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,9 @@ jobs:
         eval $(opam env --switch=${COMPILER} --set-switch)
         echo "::endgroup::"
 
-        echo "::group::Build Typed Extraction"
-        opam pin add -y coq-typed-extraction https://github.com/AU-COBRA/typed-extraction.git#6d4de5d7215226823e2c61cb77f1ff1cab1fc97d
+        echo "::group::Build MetaCoq"
+        opam remove -y coq-metacoq-erasure coq-metacoq-pcuic coq-metacoq-safechecker coq-metacoq-template
+        opam install -y --deps-only .
         echo "::endgroup::"
     - name: Build core
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         echo "::add-matcher::./.github/coq-errors.json"
         echo "::endgroup::"
     - name: Build dependencies
+      run: |
         echo "::group::Setting up switch"
         eval $(opam env --switch=${COMPILER} --set-switch)
         echo "::endgroup::"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
     - name: Checkout branch ${{ github.ref_name }}
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
     - name: Setup environment
       run: |
         echo "::group::Setting up switch"
@@ -42,14 +40,18 @@ jobs:
         echo "::group::Setting up problem matcher"
         echo "::add-matcher::./.github/coq-errors.json"
         echo "::endgroup::"
-    - name: Build core
-      run: |
+    - name: Build dependencies
         echo "::group::Setting up switch"
         eval $(opam env --switch=${COMPILER} --set-switch)
         echo "::endgroup::"
 
         echo "::group::Build Typed Extraction"
-        make -j2 typed-extraction
+        opam pin add -y coq-typed-extraction https://github.com/AU-COBRA/typed-extraction.git#6d4de5d7215226823e2c61cb77f1ff1cab1fc97d
+        echo "::endgroup::"
+    - name: Build core
+      run: |
+        echo "::group::Setting up switch"
+        eval $(opam env --switch=${COMPILER} --set-switch)
         echo "::endgroup::"
 
         echo "::group::Build Core"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "typed-extraction"]
-	path = typed-extraction
-	url = https://4ever2@github.com/AU-COBRA/typed-extraction.git

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,7 @@ all: theory plugin tests
 CoqMakefile: _CoqProject
 	coq_makefile -f _CoqProject -o CoqMakefile
 
-typed-extraction:
-	+make -C typed-extraction
-.PHONY: typed-extraction
-
-theory: CoqMakefile typed-extraction
+theory: CoqMakefile
 	+@make -f CoqMakefile
 .PHONY: theory
 
@@ -23,20 +19,17 @@ tests: theory plugin
 clean: CoqMakefile
 	+@make -f CoqMakefile clean
 	rm -f CoqMakefile
-	+@make -C typed-extraction clean
 	+@make -C plugin clean
 	+@make -C tests clean
 .PHONY: clean
 
 install: CoqMakefile
 	+@make -f CoqMakefile install
-	+@make -C typed-extraction install
 	+@make -C plugin install
 .PHONY: install
 
 uninstall: CoqMakefile
 	+@make -f CoqMakefile uninstall
-	+@make -C typed-extraction uninstall
 	+@make -C plugin uninstall
 .PHONY: uninstall
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,4 @@
--Q theories ConCert.RustExtract
+-Q theories RustExtraction
 theories/Common.v
 theories/PrettyPrinterMonad.v
 theories/Printing.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,3 @@
--Q typed-extraction/theories MetaCoq.TypedExtraction
-
 -Q theories ConCert.RustExtract
 theories/Common.v
 theories/PrettyPrinterMonad.v

--- a/coq-rust-extraction.opam
+++ b/coq-rust-extraction.opam
@@ -15,15 +15,23 @@ doc: "https://au-cobra.github.io/ConCert/toc.html"
 
 depends: [
   "coq" {>= "8.16" & < "8.17~"}
-  "coq-metacoq-template" {= "1.1.1+8.16"}
-  "coq-metacoq-pcuic" {= "1.1.1+8.16"}
-  "coq-metacoq-safechecker" {= "1.1.1+8.16"}
-  "coq-metacoq-erasure" {= "1.1.1+8.16"}
-  "coq-typed-extraction" {dev}
+  "coq-metacoq-utils" {= "8.16.dev"}
+  "coq-metacoq-common" {= "8.16.dev"}
+  "coq-metacoq-template" {= "8.16.dev"}
+  "coq-metacoq-template-pcuic" {= "8.16.dev"}
+  "coq-metacoq-pcuic" {= "8.16.dev"}
+  "coq-metacoq-safechecker" {= "8.16.dev"}
+  "coq-metacoq-erasure" {= "8.16.dev"}
 ]
 
 pin-depends: [
-  ["coq-typed-extraction.dev" "git+https://github.com/AU-COBRA/typed-extraction.git#6d4de5d7215226823e2c61cb77f1ff1cab1fc97d"]
+  ["coq-metacoq-utils.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
+  ["coq-metacoq-common.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
+  ["coq-metacoq-template.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
+  ["coq-metacoq-template-pcuic.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
+  ["coq-metacoq-pcuic.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
+  ["coq-metacoq-safechecker.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
+  ["coq-metacoq-erasure.8.16.dev" "git+https://github.com/MetaCoq/metacoq.git#b96e7570a5e7fd959fe171d63398f4491fed338a"]
 ]
 
 build: [

--- a/coq-rust-extraction.opam
+++ b/coq-rust-extraction.opam
@@ -19,6 +19,11 @@ depends: [
   "coq-metacoq-pcuic" {= "1.1.1+8.16"}
   "coq-metacoq-safechecker" {= "1.1.1+8.16"}
   "coq-metacoq-erasure" {= "1.1.1+8.16"}
+  "coq-typed-extraction" {dev}
+]
+
+pin-depends: [
+  ["coq-typed-extraction.dev" "git+https://github.com/AU-COBRA/typed-extraction.git#6d4de5d7215226823e2c61cb77f1ff1cab1fc97d"]
 ]
 
 build: [

--- a/coq-rust-extraction.opam
+++ b/coq-rust-extraction.opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "coq-rust-extraction"
+version: "dev"
+synopsis: "Coq extraction to Rust"
+description: """
+A framework for extracting Coq programs to Rust
+"""
+maintainer: "Danil Annenkov <danil.v.annenkov@gmail.com>"
+authors: "The COBRA team"
+license: "MIT"
+homepage: "https://github.com/AU-COBRA/coq-rust-extraction"
+dev-repo: "git+https://github.com/AU-COBRA/coq-rust-extraction.git"
+bug-reports: "https://github.com/AU-COBRA/coq-rust-extraction/issues"
+doc: "https://au-cobra.github.io/ConCert/toc.html"
+
+depends: [
+  "coq" {>= "8.16" & < "8.17~"}
+  "coq-metacoq-template" {= "1.1.1+8.16"}
+  "coq-metacoq-pcuic" {= "1.1.1+8.16"}
+  "coq-metacoq-safechecker" {= "1.1.1+8.16"}
+  "coq-metacoq-erasure" {= "1.1.1+8.16"}
+]
+
+build: [
+  [make "plugin"]
+  [make "tests"] {with-test}
+]
+install: [
+  [make "install"]
+  [make "-C" "tests" "install"] {with-test}
+]

--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -56,16 +56,12 @@ src/pCUICCases.ml
 src/pCUICCases.mli
 src/pCUICErrors.ml
 src/pCUICErrors.mli
-src/pCUICEquality.ml
-src/pCUICEquality.mli
 src/pCUICEqualityDec.ml
 src/pCUICEqualityDec.mli
 src/pCUICNormal.ml
 src/pCUICNormal.mli
 src/pCUICPosition.ml
 src/pCUICPosition.mli
-src/pCUICPretty.ml
-src/pCUICPretty.mli
 src/pCUICProgram.ml
 src/pCUICProgram.mli
 src/pCUICPrimitive.ml
@@ -80,8 +76,6 @@ src/pCUICWfEnv.ml
 src/pCUICWfEnv.mli
 src/pCUICWfEnvImpl.ml
 src/pCUICWfEnvImpl.mli
-src/pCUICWfUniverses.ml
-src/pCUICWfUniverses.mli
 src/prettyPrinterMonad.ml
 src/prettyPrinterMonad.mli
 src/printing.ml

--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -1,7 +1,7 @@
--Q ../theories ConCert.RustExtract
+-Q ../theories RustExtraction
 
--Q theories ConCert.RustExtract
--generate-meta-for-package coq-concert-extraction
+-Q theories RustExtraction
+-generate-meta-for-package coq-rust-extraction
 -I src
 
 src/certifyingBeta.ml
@@ -115,8 +115,8 @@ src/vectorDef.mli
 src/wGraph.ml
 src/wGraph.mli
 
-src/g_concert_extraction.mlg
-src/concert_extraction_plugin.mlpack
+src/g_rust_extraction.mlg
+src/rust_extraction_plugin.mlpack
 
 theories/ExtrRustBasic.v
 theories/ExtrRustCheckedArith.v

--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -1,4 +1,3 @@
--Q ../typed-extraction/theories MetaCoq.TypedExtraction
 -Q ../theories ConCert.RustExtract
 
 -Q theories ConCert.RustExtract

--- a/plugin/src/.gitignore
+++ b/plugin/src/.gitignore
@@ -166,4 +166,4 @@ vectorDef.mli
 wGraph.ml
 wGraph.mli
 
-g_concert_extraction.ml
+g_rust_extraction.ml

--- a/plugin/src/g_rust_extraction.mlg
+++ b/plugin/src/g_rust_extraction.mlg
@@ -1,4 +1,4 @@
-DECLARE PLUGIN "coq-concert-extraction.plugin"
+DECLARE PLUGIN "coq-rust-extraction.plugin"
 
 {
 
@@ -110,8 +110,8 @@ let check env evm c =
 
 }
 
-VERNAC COMMAND EXTEND ConCertExtract CLASSIFIED AS QUERY
-| [ "ConCert" "Extract" constr(c) ] -> {
+VERNAC COMMAND EXTEND RustExtract CLASSIFIED AS QUERY
+| [ "Rust" "Extract" constr(c) ] -> {
     let env = Global.env () in
     let evm = Evd.from_env env in
     let (c, _) = Constrintern.interp_constr env evm c in

--- a/plugin/src/rust_extraction_plugin.mlpack
+++ b/plugin/src/rust_extraction_plugin.mlpack
@@ -19,13 +19,10 @@ PCUICAst
 PCUICAstUtils
 PCUICChecker
 PCUICCumulativity
-PCUICEquality
 PCUICEqualityDec
 PCUICLiftSubst
-PCUICPretty
 PCUICErrors
 PCUICCases
-PCUICWfUniverses
 PCUICNormal
 PCUICPosition
 PCUICReduction

--- a/plugin/src/rust_extraction_plugin.mlpack
+++ b/plugin/src/rust_extraction_plugin.mlpack
@@ -77,4 +77,4 @@ Extraction0
 RustExtract
 PluginExtract
 
-G_concert_extraction
+G_rust_extraction

--- a/plugin/theories/Loader.v
+++ b/plugin/theories/Loader.v
@@ -3,4 +3,4 @@ From MetaCoq.Template Require ExtractableLoader.
 
 (* Declare ML Module "extraction_plugin". *)
 (* Declare ML Module "coq-metacoq-template-coq.plugin". *)
-Declare ML Module "coq-concert-extraction.plugin".
+Declare ML Module "coq-rust-extraction.plugin".

--- a/process_extraction.sh
+++ b/process_extraction.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ ! -f "plugin/src/concert_extraction_plugin.cmxs" ||
-      "plugin/src/concert_extraction_plugin.cmxs" -ot "theories/ExtractExtraction.vo" ]]
+if [[ ! -f "plugin/src/rust_extraction_plugin.cmxs" ||
+      "plugin/src/rust_extraction_plugin.cmxs" -ot "theories/ExtractExtraction.vo" ]]
 then
   cd plugin/src
   # Uncapitalize modules to circumvent a bug of coqdep with mlpack files

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -1,4 +1,3 @@
--Q ../typed-extraction/theories MetaCoq.TypedExtraction
 -Q ../theories ConCert.RustExtract
 -Q ../plugin/theories ConCert.RustExtract
 

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -1,7 +1,7 @@
--Q ../theories ConCert.RustExtract
--Q ../plugin/theories ConCert.RustExtract
+-Q ../theories RustExtraction
+-Q ../plugin/theories RustExtraction
 
--Q theories ConCert.RustExtract.Test
+-Q theories RustExtraction.Test
 -I ../plugin/src
 theories/BernsteinYangTermination.v
 theories/InternalFix.v

--- a/tests/extracted-code/Ack.main
+++ b/tests/extracted-code/Ack.main
@@ -1,3 +1,3 @@
 fn main() {
-  println!("{:?}", Program::new().ConCert_RustExtract_Test_InternalFix_ack(3,4))
+  println!("{:?}", Program::new().RustExtraction_Test_InternalFix_ack(3,4))
 }

--- a/tests/extracted-code/BernsteinYangTermination.main
+++ b/tests/extracted-code/BernsteinYangTermination.main
@@ -1,3 +1,3 @@
 fn main() {
-  println!("{:?}", Program::new().ConCert_RustExtract_Test_BernsteinYangTermination_W(10))
+  println!("{:?}", Program::new().RustExtraction_Test_BernsteinYangTermination_W(10))
 }

--- a/tests/extracted-code/Even.main
+++ b/tests/extracted-code/Even.main
@@ -1,3 +1,3 @@
 fn main() {
-  println!("{:?}", Program::new().ConCert_RustExtract_Test_InternalFix_even()(42))
+  println!("{:?}", Program::new().RustExtraction_Test_InternalFix_even()(42))
 }

--- a/tests/theories/BernsteinYangTermination.v
+++ b/tests/theories/BernsteinYangTermination.v
@@ -1,6 +1,6 @@
 (* Computation needed to show termination of the Bernstein-Yang modular inversion algorithm *)
 
-From ConCert.RustExtract Require Import Loader.
+From RustExtraction Require Import Loader.
 From Coq Require Import Bool.
 From Coq Require Import ZArith.
 
@@ -43,6 +43,6 @@ Extract Constant nat_shiftl => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a
 Extract Constant shiftl => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a << b }".
 Extract Constant shiftr => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a >> b }".
 
-From ConCert.RustExtract Require Import ExtrRustBasic.
-From ConCert.RustExtract Require Import ExtrRustUncheckedArith.
-Redirect "extracted-code/BernsteinYangTermination.rs" ConCert Extract W.
+From RustExtraction Require Import ExtrRustBasic.
+From RustExtraction Require Import ExtrRustUncheckedArith.
+Redirect "extracted-code/BernsteinYangTermination.rs" Rust Extract W.

--- a/tests/theories/InternalFix.v
+++ b/tests/theories/InternalFix.v
@@ -1,5 +1,5 @@
 (** Examples of (mutual) nested fixpoints *)
-From ConCert.RustExtract Require Import Loader.
+From RustExtraction Require Import Loader.
 From Coq Require Import Arith.
 From Coq Require Import Bool.
 From Coq Require Import Extraction.
@@ -32,8 +32,8 @@ Fixpoint even n :=
 
 Definition even_odd (n : nat) : bool := even n.
 
-From ConCert.RustExtract Require Import ExtrRustBasic.
-From ConCert.RustExtract Require Import ExtrRustUncheckedArith.
+From RustExtraction Require Import ExtrRustBasic.
+From RustExtraction Require Import ExtrRustUncheckedArith.
 
-Redirect "extracted-code/Ack.rs" ConCert Extract ack.
-Redirect "extracted-code/Even.rs" ConCert Extract even.
+Redirect "extracted-code/Ack.rs" Rust Extract ack.
+Redirect "extracted-code/Even.rs" Rust Extract even.

--- a/tests/theories/RustExtractTests.v
+++ b/tests/theories/RustExtractTests.v
@@ -1,12 +1,12 @@
 (** * Tests for extraction to Rust *)
-From MetaCoq.TypedExtraction Require Import Extraction.
-From MetaCoq.TypedExtraction Require Import ResultMonad.
+From MetaCoq.Erasure.Typed Require Import Extraction.
+From MetaCoq.Erasure.Typed Require Import ResultMonad.
 From RustExtraction Require Import RustExtract.
 From RustExtraction Require Import Printing.
 From RustExtraction Require Import StringExtra.
 From MetaCoq.Template Require Import Ast.
-From MetaCoq.Template Require Import Kernames.
-From MetaCoq Require Import utils.
+From MetaCoq.Common Require Import Kernames.
+From MetaCoq.Utils Require Import utils.
 From Coq Require Import String.
 
 Import PrettyPrinterMonad.

--- a/tests/theories/RustExtractTests.v
+++ b/tests/theories/RustExtractTests.v
@@ -1,9 +1,9 @@
 (** * Tests for extraction to Rust *)
 From MetaCoq.TypedExtraction Require Import Extraction.
 From MetaCoq.TypedExtraction Require Import ResultMonad.
-From ConCert.RustExtract Require Import RustExtract.
-From ConCert.RustExtract Require Import Printing.
-From ConCert.RustExtract Require Import StringExtra.
+From RustExtraction Require Import RustExtract.
+From RustExtraction Require Import Printing.
+From RustExtraction Require Import StringExtra.
 From MetaCoq.Template Require Import Ast.
 From MetaCoq.Template Require Import Kernames.
 From MetaCoq Require Import utils.

--- a/theories/Common.v
+++ b/theories/Common.v
@@ -1,13 +1,13 @@
 From Coq Require Import String.
-From MetaCoq.TypedExtraction Require Import ResultMonad.
-From MetaCoq.TypedExtraction Require Import Utils.
+From MetaCoq.Erasure.Typed Require Import ResultMonad.
+From MetaCoq.Erasure.Typed Require Import Utils.
 From MetaCoq.Template Require Import Ast.
 From MetaCoq.Template Require Import LiftSubst.
 From MetaCoq.Template Require Import AstUtils.
 From MetaCoq.Template Require Import Loader.
 From MetaCoq.Template Require Import TemplateMonad.
 From MetaCoq.Template Require Import Typing.
-From MetaCoq.Template Require Import utils.
+From MetaCoq.Utils Require Import utils.
 From MetaCoq.Erasure Require EAst.
 From MetaCoq.SafeChecker Require Import PCUICSafeChecker.
 From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.

--- a/theories/ExtractExtraction.v
+++ b/theories/ExtractExtraction.v
@@ -17,7 +17,7 @@ Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".
 
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst EGlobalEnv Extract ErasureFunction Erasure.
-From ConCert.RustExtract Require Import PluginExtract.
+From RustExtraction Require Import PluginExtract.
 From MetaCoq.TypedExtraction Require Import Utils.
 
 
@@ -52,6 +52,6 @@ bytestrings from MetaCoq that leads to clashes. E.g. we cannot use
 Cd "plugin/src".
 Separate Extraction PluginExtract.extract
          (* The following directives ensure separate extraction does not produce name clashes *)
-          Bool Nat Coq.Strings.String bytestring.String RustExtract.Common TemplateMonad.Common utils ELiftSubst EGlobalEnv Template.Transform ResultMonad PCUICPretty.
+          Bool Nat Coq.Strings.String bytestring.String RustExtraction.Common TemplateMonad.Common utils ELiftSubst EGlobalEnv Template.Transform ResultMonad PCUICPretty.
          (* Bool Nat Coq.Strings.String Common utils ELiftSubst EGlobalEnv PCUICLiftSubst PCUICUnivSubst ResultMonad SafeTemplateChecker. *)
 Cd "../..".

--- a/theories/ExtractExtraction.v
+++ b/theories/ExtractExtraction.v
@@ -1,6 +1,6 @@
 (* This file is based on erasure/theories/Extraction.v from MetaCoq *)
 From Coq Require Import Ascii FSets ExtrOcamlBasic ExtrOCamlFloats ExtrOCamlInt63.
-From MetaCoq.Template Require Import utils.
+From MetaCoq.Utils Require Import utils.
 
 (* Ignore [Decimal.int] before the extraction issue is solved:
     https://github.com/coq/coq/issues/7017. *)
@@ -18,7 +18,7 @@ Set Warnings "-extraction-reserved-identifier".
 
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst EGlobalEnv Extract ErasureFunction Erasure.
 From RustExtraction Require Import PluginExtract.
-From MetaCoq.TypedExtraction Require Import Utils.
+From MetaCoq.Erasure.Typed Require Import Utils.
 
 
 Extraction Inline Equations.Prop.Classes.noConfusion.
@@ -52,6 +52,7 @@ bytestrings from MetaCoq that leads to clashes. E.g. we cannot use
 Cd "plugin/src".
 Separate Extraction PluginExtract.extract
          (* The following directives ensure separate extraction does not produce name clashes *)
-          Bool Nat Coq.Strings.String bytestring.String RustExtraction.Common TemplateMonad.Common utils ELiftSubst EGlobalEnv Template.Transform ResultMonad PCUICPretty.
-         (* Bool Nat Coq.Strings.String Common utils ELiftSubst EGlobalEnv PCUICLiftSubst PCUICUnivSubst ResultMonad SafeTemplateChecker. *)
+          Bool Nat Coq.Strings.String bytestring.String RustExtraction.Common TemplateMonad.Common utils ELiftSubst EGlobalEnv Common.Transform ResultMonad.
 Cd "../..".
+
+(* Definition . *)

--- a/theories/PluginExtract.v
+++ b/theories/PluginExtract.v
@@ -1,14 +1,14 @@
 (** * Definitions below are used in the extracted plugin *)
 
-From MetaCoq.TypedExtraction Require Import ExAst.
-From MetaCoq.TypedExtraction Require Import Extraction.
-From MetaCoq.TypedExtraction Require Import ResultMonad.
-From MetaCoq.TypedExtraction Require Import Utils.
+From MetaCoq.Erasure.Typed Require Import ExAst.
+From MetaCoq.Erasure.Typed Require Import Extraction.
+From MetaCoq.Erasure.Typed Require Import ResultMonad.
+From MetaCoq.Erasure.Typed Require Import Utils.
 From RustExtraction Require Import PrettyPrinterMonad.
 From RustExtraction Require Import Printing.
 From RustExtraction Require Import RustExtract.
-From MetaCoq.Template Require Import Kernames.
-From MetaCoq.Template Require Import monad_utils.
+From MetaCoq.Common Require Import Kernames.
+From MetaCoq.Utils Require Import monad_utils.
 From Coq Require Import List.
 From Coq Require Import String.
 

--- a/theories/PluginExtract.v
+++ b/theories/PluginExtract.v
@@ -4,9 +4,9 @@ From MetaCoq.TypedExtraction Require Import ExAst.
 From MetaCoq.TypedExtraction Require Import Extraction.
 From MetaCoq.TypedExtraction Require Import ResultMonad.
 From MetaCoq.TypedExtraction Require Import Utils.
-From ConCert.RustExtract Require Import PrettyPrinterMonad.
-From ConCert.RustExtract Require Import Printing.
-From ConCert.RustExtract Require Import RustExtract.
+From RustExtraction Require Import PrettyPrinterMonad.
+From RustExtraction Require Import Printing.
+From RustExtraction Require Import RustExtract.
 From MetaCoq.Template Require Import Kernames.
 From MetaCoq.Template Require Import monad_utils.
 From Coq Require Import List.

--- a/theories/PrettyPrinterMonad.v
+++ b/theories/PrettyPrinterMonad.v
@@ -5,7 +5,7 @@ From MetaCoq.Template Require Import monad_utils.
 From MetaCoq.SafeChecker Require Import PCUICErrors.
 From MetaCoq.TypedExtraction Require Import Utils.
 From MetaCoq.TypedExtraction Require Import ResultMonad.
-From ConCert.RustExtract Require Import Common.
+From RustExtraction Require Import Common.
 
 Import monad_utils.MCMonadNotation.
 Import ListNotations.

--- a/theories/PrettyPrinterMonad.v
+++ b/theories/PrettyPrinterMonad.v
@@ -1,10 +1,10 @@
 From Coq Require Import List.
 From Coq Require Import Ascii.
 From Coq Require Import String.
-From MetaCoq.Template Require Import monad_utils.
+From MetaCoq.Utils Require Import monad_utils.
 From MetaCoq.SafeChecker Require Import PCUICErrors.
-From MetaCoq.TypedExtraction Require Import Utils.
-From MetaCoq.TypedExtraction Require Import ResultMonad.
+From MetaCoq.Erasure.Typed Require Import Utils.
+From MetaCoq.Erasure.Typed Require Import ResultMonad.
 From RustExtraction Require Import Common.
 
 Import monad_utils.MCMonadNotation.

--- a/theories/Printing.v
+++ b/theories/Printing.v
@@ -1,5 +1,5 @@
-From MetaCoq.Template Require Import BasicAst.
-From MetaCoq.Template Require Import MCString.
+From MetaCoq.Common Require Import BasicAst.
+From MetaCoq.Utils Require Import MCString.
 
 Record remapped_inductive := build_remapped_inductive {
   re_ind_name : string;

--- a/theories/RustExtract.v
+++ b/theories/RustExtract.v
@@ -10,10 +10,10 @@ From Coq Require Import Ascii.
 From Coq Require Import String.
 From Coq Require Import List.
 From Coq.Program Require Import Basics.
-From ConCert.RustExtract Require Import Printing.
-From ConCert.RustExtract Require Import TopLevelFixes.
-From ConCert.RustExtract Require Import StringExtra.
-From ConCert.RustExtract Require Import PrettyPrinterMonad.
+From RustExtraction Require Import Printing.
+From RustExtraction Require Import TopLevelFixes.
+From RustExtraction Require Import StringExtra.
+From RustExtraction Require Import PrettyPrinterMonad.
 
 Module P := MetaCoq.PCUIC.PCUICAst.
 Module PT := MetaCoq.PCUIC.PCUICTyping.

--- a/theories/RustExtract.v
+++ b/theories/RustExtract.v
@@ -1,10 +1,10 @@
-From MetaCoq.Template Require Import monad_utils.
-From MetaCoq.Template Require Import MCList.
-From MetaCoq.TypedExtraction Require Import ExAst.
-From MetaCoq.TypedExtraction Require Import Extraction.
-From MetaCoq.TypedExtraction Require Import CertifyingInlining.
-From MetaCoq.TypedExtraction Require Import Optimize.
-From MetaCoq.TypedExtraction Require Import ResultMonad.
+From MetaCoq.Utils Require Import monad_utils.
+From MetaCoq.Utils Require Import MCList.
+From MetaCoq.Erasure.Typed Require Import ExAst.
+From MetaCoq.Erasure.Typed Require Import Extraction.
+From MetaCoq.Erasure.Typed Require Import CertifyingInlining.
+From MetaCoq.Erasure.Typed Require Import Optimize.
+From MetaCoq.Erasure.Typed Require Import ResultMonad.
 From Coq Require Import PeanoNat.
 From Coq Require Import Ascii.
 From Coq Require Import String.
@@ -17,12 +17,12 @@ From RustExtraction Require Import PrettyPrinterMonad.
 
 Module P := MetaCoq.PCUIC.PCUICAst.
 Module PT := MetaCoq.PCUIC.PCUICTyping.
-Module T2P := MetaCoq.PCUIC.TemplateToPCUIC.
+Module T2P := MetaCoq.TemplatePCUIC.TemplateToPCUIC.
 Module E := MetaCoq.Erasure.EAst.
 Module T := MetaCoq.Template.Ast.
 Module TUtil := MetaCoq.Template.AstUtils.
 Module EF := MetaCoq.Erasure.ErasureFunction.
-Module Ex := MetaCoq.TypedExtraction.ExAst.
+Module Ex := MetaCoq.Erasure.Typed.ExAst.
 
 Local Open Scope string.
 

--- a/theories/TopLevelFixes.v
+++ b/theories/TopLevelFixes.v
@@ -3,10 +3,10 @@
    is instead changed into something like [("Foo", tConst "Foo")]. *)
 From Coq Require Import List.
 From Coq Require Import String.
-From MetaCoq.TypedExtraction Require Import ExAst.
-From MetaCoq.TypedExtraction Require Import ResultMonad.
-From MetaCoq.TypedExtraction Require Import Transform.
-From MetaCoq.TypedExtraction Require Import Utils.
+From MetaCoq.Erasure.Typed Require Import ExAst.
+From MetaCoq.Erasure.Typed Require Import ResultMonad.
+From MetaCoq.Erasure.Typed Require Import Transform.
+From MetaCoq.Erasure.Typed Require Import Utils.
 From MetaCoq.Erasure Require Import ELiftSubst.
 From MetaCoq Require Import utils.
 


### PR DESCRIPTION
Add opam file and remove the typed-extraction submodule. Also renames the package from `ConCert.RustExtract` to `RustExtraction`.