### PR TITLE
Fix MetaCoq utils imports

### DIFF
--- a/theories/TopLevelFixes.v
+++ b/theories/TopLevelFixes.v
@@ -8,7 +8,7 @@ From MetaCoq.Erasure.Typed Require Import ResultMonad.
 From MetaCoq.Erasure.Typed Require Import Transform.
 From MetaCoq.Erasure.Typed Require Import Utils.
 From MetaCoq.Erasure Require Import ELiftSubst.
-From MetaCoq Require Import utils.
+From MetaCoq.Utils Require Import utils.
 
 Import ListNotations.
 


### PR DESCRIPTION
Building fails when `coq-metacoq-quotation` is installed because the import statement From MetaCoq Require Import utils isn't specific enough.