### PR TITLE
Use ubuntu-22.04 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ env:
   JOBS: 4
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/lint-opam.yml
+++ b/.github/workflows/lint-opam.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up opam
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.x
           opam-repositories: |

--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -12,7 +12,7 @@ env:
   OCAML_COMILER_VERSION: "4.14.2"
 jobs:
   cache:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v4


### PR DESCRIPTION
The `ubuntu-latest` image is switching from `ubuntu-22.04` to `ubuntu-24.04`, this breaks `setup-ocaml@v1` which we depend on in CI.