### PR TITLE
[8.19] Switch to bytestrings

### DIFF
--- a/tests/theories/RustExtractTests.v
+++ b/tests/theories/RustExtractTests.v
@@ -7,11 +7,13 @@ From RustExtraction Require Import StringExtra.
 From MetaCoq.Template Require Import Ast.
 From MetaCoq.Common Require Import Kernames.
 From MetaCoq.Utils Require Import utils.
-From Coq Require Import String.
+From MetaCoq.Utils Require Import bytestring.
+
 
 Import PrettyPrinterMonad.
 Import MCMonadNotation.
-Local Open Scope string.
+Local Open Scope bs_scope.
+
 
 Local Instance RustConfig : RustPrintConfig :=
   {| term_box_symbol := "()";
@@ -25,7 +27,7 @@ Definition extract (p : program) : result _ _ :=
   entry <- match p.2 with
            | T.tConst kn _ => ret kn
            | T.tInd ind _ => ret (inductive_mind ind)
-           | _ => Err (s_to_bs "Expected program to be a tConst or tInd")
+           | _ => Err "Expected program to be a tConst or tInd"
            end;;
   Σ <- extract_template_env
          (extract_rust_within_coq (fun _ => None) (fun _ => false))
@@ -47,7 +49,7 @@ Definition extract (p : program) : result _ _ :=
       append_nl;;
       print_decls Σ no_remaps default_attrs (filter is_const (List.rev Σ));;
       ret tt in
-  '(_, s) <- map_error (fun x => s_to_bs x) (finish_print p);;
+  '(_, s) <- (finish_print p);;
   ret s.
 
 Module ex1.
@@ -324,7 +326,7 @@ Module SafeHead.
   Qed.
 
   MetaCoq Run (p <- Core.tmQuoteRecTransp (@head_of_repeat_plus_one) false;;
-               Core.tmDefinition (s_to_bs "Prog") p).
+               Core.tmDefinition "Prog" p).
 
   Example test :
     extract Prog = Ok <$

--- a/theories/Common.v
+++ b/theories/Common.v
@@ -1,4 +1,3 @@
-From Coq Require Import String.
 From MetaCoq.Erasure.Typed Require Import ResultMonad.
 From MetaCoq.Erasure.Typed Require Import Utils.
 From MetaCoq.Template Require Import Ast.
@@ -8,12 +7,15 @@ From MetaCoq.Template Require Import Loader.
 From MetaCoq.Template Require Import TemplateMonad.
 From MetaCoq.Template Require Import Typing.
 From MetaCoq.Utils Require Import utils.
+From MetaCoq.Utils Require Import bytestring.
 From MetaCoq.Erasure Require EAst.
 From MetaCoq.SafeChecker Require Import PCUICSafeChecker.
 From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
+From Coq.Strings Require Import Byte.
 
 Import PCUICErrors.
 Import MCMonadNotation.
+Import String.
 
 
 Definition to_globref (t : Ast.term) : option global_reference :=
@@ -56,7 +58,7 @@ Definition extract_def_name_exists {A : Type} (a : A) : TemplateMonad kername :=
 Notation "'unfolded' d" :=
   ltac:(let y := eval unfold d in d in exact y) (at level 100, only parsing).
 
-Definition remap (kn : kername) (new_name : String.string) : kername * String.string :=
+Definition remap (kn : kername) (new_name : string) : kername * string :=
   (kn, new_name).
 
 Definition quote_recursively_body {A : Type} (def : A) : TemplateMonad program :=
@@ -172,24 +174,22 @@ Definition Z_syn_to_Z (t : EAst.term) : option Z :=
   | _ => None
   end.
 
-(* TODO: port the pretty-printers to use bytestring and use metacoq's MCString utils *)
-
-Definition parens (top : bool) (s : String.string) : String.string :=
+Definition parens (top : bool) (s : string) : string :=
   if top then s else "(" ++ s ++ ")".
 
-Definition nl : String.string := String (Ascii.ascii_of_nat 10) EmptyString.
+Definition nl : string := String x0a EmptyString.
 
-Definition string_of_list_aux {A} (f : A -> String.string) (sep : String.string) (l : list A) : String.string :=
+Definition string_of_list_aux {A} (f : A -> string) (sep : string) (l : list A) : string :=
   let fix aux l :=
-      match l return String.string with
-      | nil => ""%string
+      match l return string with
+      | nil => ""
       | cons a nil => f a
-      | cons a l => (f a ++ sep ++ aux l)%string
+      | cons a l => (f a ++ sep ++ aux l)
       end
   in aux l.
 
-Definition string_of_list {A} (f : A -> String.string) (l : list A) : String.string :=
-  ("[" ++ string_of_list_aux f "," l ++ "]")%string.
+Definition string_of_list {A} (f : A -> string) (l : list A) : string :=
+  ("[" ++ string_of_list_aux f "," l ++ "]").
 
-Definition print_list {A} (f : A -> String.string) (sep : String.string) (l : list A) : String.string :=
+Definition print_list {A} (f : A -> string) (sep : string) (l : list A) : string :=
   string_of_list_aux f sep l.

--- a/theories/PluginExtract.v
+++ b/theories/PluginExtract.v
@@ -11,11 +11,10 @@ From MetaCoq.Common Require Import Kernames.
 From MetaCoq.Utils Require Import monad_utils.
 From Coq Require Import List.
 From Coq Require Import String.
+From MetaCoq.Utils Require Import bytestring.
 
 Import ListNotations.
 Import MCMonadNotation.
-
-Open Scope string.
 
 Local Instance plugin_extract_preamble : Preamble :=
 {| top_preamble := [
@@ -145,7 +144,7 @@ Definition extract_lines
   entry <- match snd p with
            | T.tConst kn _ => ret kn
            | T.tInd ind _ => ret (inductive_mind ind)
-           | _ => Err (s_to_bs "Expected program to be a tConst or tInd")
+           | _ => Err "Expected program to be a tConst or tInd"
            end;;
   let without_deps kn :=
       if remap_inductive remaps (mkInd kn 0) then true else
@@ -157,8 +156,8 @@ Definition extract_lines
          (KernameSet.singleton entry)
          without_deps;;
   let p := print_program Σ remaps default_attrs in
-  '(_, s) <- timed "Printing" (fun _ => map_error (fun x => s_to_bs x) (finish_print_lines p));;
-  Ok (map s_to_bs s).
+  '(_, s) <- timed "Printing"%string (fun _ => (finish_print_lines p));;
+  Ok s.
 
 Definition extract p remaps should_inline :=
   lines <- extract_lines p remaps should_inline;;

--- a/theories/PrettyPrinterMonad.v
+++ b/theories/PrettyPrinterMonad.v
@@ -1,15 +1,15 @@
 From Coq Require Import List.
-From Coq Require Import Ascii.
-From Coq Require Import String.
 From MetaCoq.Utils Require Import monad_utils.
+From MetaCoq.Utils Require Import bytestring.
 From MetaCoq.SafeChecker Require Import PCUICErrors.
 From MetaCoq.Erasure.Typed Require Import Utils.
 From MetaCoq.Erasure.Typed Require Import ResultMonad.
 From RustExtraction Require Import Common.
 
+Import String.
 Import monad_utils.MCMonadNotation.
 Import ListNotations.
-Local Open Scope string.
+Local Open Scope bs_scope.
 
 Import Kernames.
 
@@ -20,11 +20,6 @@ Record PrettyPrinterState :=
     output_lines : list (nat * string);
     cur_output_line : nat * string;
   }.
-
-Notation bs_to_s := bytestring.String.to_string.
-Notation s_to_bs := bytestring.String.of_string.
-
-Local Coercion bs_to_s : bytestring.string >-> string.
 
 Definition PrettyPrinter A :=
   PrettyPrinterState -> result (A * PrettyPrinterState) string.
@@ -51,7 +46,7 @@ Definition map_pps
 Fixpoint prefix_spaces n s :=
   match n with
   | 0 => s
-  | S n => prefix_spaces n (String " "%char s)
+  | S n => prefix_spaces n (String " " s)
   end.
 
 Definition collect_output_lines pps :=
@@ -139,7 +134,7 @@ Definition fresh_name (name : ident) (extra_used : list ident) : PrettyPrinter i
   if existsb (bytestring.String.eqb name) used then
     (fix f n i :=
        match n with
-       | 0 => ret (s_to_bs "unreachable")
+       | 0 => ret "unreachable"
        | S n =>
          let numbered_name := bytestring.String.append name (MCString.string_of_nat i) in
          if existsb (bytestring.String.eqb numbered_name) used then
@@ -153,9 +148,9 @@ Definition fresh_name (name : ident) (extra_used : list ident) : PrettyPrinter i
 Definition string_of_env_error Σ e :=
   match e with
   | IllFormedDecl s e =>
-    ("IllFormedDecl " ++ s ++ "\nType error: " ++ string_of_type_error Σ e)%string
+    "IllFormedDecl " ++ s ++ "\nType error: " ++ string_of_type_error Σ e
   | AlreadyDeclared s => "Alreadydeclared " ++ s
-  end%string.
+  end.
 
 Definition wrap_EnvCheck {astr A} f (ec : EnvCheck astr A) : PrettyPrinter A :=
   match ec with


### PR DESCRIPTION
Update the pipeline to use MetaCoq bytestrings instead of strings.