### PR TITLE
[8.19] Update rust setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,8 @@ jobs:
           name: extraction-results
           path: tests/extracted-code
 
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
 


### PR DESCRIPTION
We switch to using `dtolnay/rust-toolchain` for configuring Rust in CI.
This is necessary since the old setup uses features that are deprecated and set to be removed.